### PR TITLE
Make TextureWrapper class to avoid boxing

### DIFF
--- a/src/Peridot.Veldrid/Peridot.Veldrid.csproj
+++ b/src/Peridot.Veldrid/Peridot.Veldrid.csproj
@@ -1,37 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<Description>Peridot implementation using Veldrid lib.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Description>Peridot implementation using Veldrid lib.</Description>
+  </PropertyGroup>
 
-	<Import Project="..\build\common.props.csproj" />
+  <!--	<Import Project="..\build\common.props.csproj" />-->
 
-	<ItemGroup>
-	  <PackageReference Include="Ez.Memory" Version="0.2.0-alpha" />
-	  <PackageReference Include="FontStashSharp" Version="1.0.4" />
-	  <PackageReference Include="Veldrid" Version="4.8.0" />
-	  <PackageReference Include="Veldrid.SPIRV" Version="1.0.14" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Ez.Memory" Version="0.2.0-alpha"/>
+    <PackageReference Include="FontStashSharp" Version="1.0.4"/>
+    <PackageReference Include="Veldrid" Version="4.8.0"/>
+    <PackageReference Include="Veldrid.SPIRV" Version="1.0.14"/>
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Peridot\Peridot.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Peridot\Peridot.csproj"/>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Update="Resource.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Resource.resx</DependentUpon>
-		</Compile>
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resource.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-	<ItemGroup>
-		<EmbeddedResource Update="Resource.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Resource.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resource.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Peridot.Veldrid/TextureWrapper.cs
+++ b/src/Peridot.Veldrid/TextureWrapper.cs
@@ -5,59 +5,58 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using Veldrid;
 
-namespace Peridot.Veldrid
-{
+namespace Peridot.Veldrid;
+
+/// <summary>
+/// A wrapper with <see cref="ITexture2D"/> interface.
+/// </summary>
+public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
     /// <summary>
-    /// A wrapper with <see cref="ITexture2D"/> interface.
+    /// Creates a new instance of <see cref="TextureWrapper"/>.
     /// </summary>
-    public struct TextureWrapper : ITexture2D, IEquatable<TextureWrapper>
-    {
-        /// <summary>
-        /// Creates a new instance of <see cref="TextureWrapper"/>.
-        /// </summary>
-        /// <param name="texture">The texture.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public TextureWrapper(Texture texture)
-        {
-            if (texture is null)
-                throw new ArgumentNullException(nameof(texture));
-
-            Texture = texture;
-        }
-
-        /// <summary>
-        /// Texture
-        /// </summary>
-        public Texture Texture { get; }
-
-        /// <summary>
-        /// Size of texture
-        /// </summary>
-        public Size Size => new((int)Texture.Width, (int)Texture.Height);
-
-        /// <inheritdoc/>
-        public bool IsDisposed => Texture.IsDisposed;
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => Texture.GetHashCode();
-
-        /// <inheritdoc/>
-        public bool Equals(TextureWrapper other) => Texture == other.Texture;
-
-        /// <inheritdoc/>
-        public override bool Equals([NotNullWhen(true)] object? obj) =>
-            obj is not null && obj is TextureWrapper tw && Equals(tw);
-
-        /// <inheritdoc/>
-        public override string? ToString() => Texture.ToString();
-
-        /// <inheritdoc/>
-        public void Dispose() => Texture.Dispose();
-
-        /// <inheritdoc/>
-        public static implicit operator TextureWrapper(Texture t) => new(t);
-
-        /// <inheritdoc/>
-        public static implicit operator Texture(TextureWrapper t) => t.Texture;
+    /// <param name="texture">The texture.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public TextureWrapper(Texture texture) {
+        Texture = texture ?? throw new ArgumentNullException(nameof(texture));
     }
+
+    /// <summary>
+    /// Texture
+    /// </summary>
+    public Texture Texture { get; }
+
+    /// <summary>
+    /// Size of texture
+    /// </summary>
+    public Size Size => new((int) Texture.Width, (int) Texture.Height);
+
+    /// <inheritdoc/>
+    public bool IsDisposed => Texture.IsDisposed;
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Texture.GetHashCode();
+
+    /// <inheritdoc/>
+    public bool Equals(TextureWrapper? other) => Texture == other?.Texture;
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj) =>
+        obj is TextureWrapper tw && Equals(tw);
+
+    /// <inheritdoc/>
+    public override string? ToString() => Texture.ToString();
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        Texture.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public static implicit operator TextureWrapper(Texture t) => new(t);
+
+    public static implicit operator Texture(TextureWrapper t) => t.Texture;
+
+    public static bool operator ==(TextureWrapper left, TextureWrapper right) => left.Equals(right);
+
+    public static bool operator !=(TextureWrapper left, TextureWrapper right) => !(left == right);
 }


### PR DESCRIPTION
I noticed memory allocations going through the roof, because TextureWrapper was being boxed when sent as an ITexture. It should probably be a class instead. At least my memory allocations have gone away.

(Sorry about the formatting changes 😅 could you maybe add an .editorconfig to keep the style consistent?)