### PR TITLE
Make TextureWrapper class to avoid boxing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,131 @@
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/Peridot.sln
+++ b/Peridot.sln
@@ -7,12 +7,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peridot", "src\Peridot\Peri
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peridot.Veldrid", "src\Peridot.Veldrid\Peridot.Veldrid.csproj", "{06D982B2-97D8-4C38-9837-50D2EA5E050D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Peridot.Demo", "src\Peridot.Demo\Peridot.Demo.csproj", "{2B5DA501-2051-4045-A3C7-B5E9C74DE7ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Peridot.Demo", "src\Peridot.Demo\Peridot.Demo.csproj", "{2B5DA501-2051-4045-A3C7-B5E9C74DE7ED}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F5D6FEB2-6E90-4034-83E4-78BCA8EDDA25}"
 	ProjectSection(SolutionItems) = preProject
 		src\build\common.props.csproj = src\build\common.props.csproj
 		src\build\peridot.png = src\build\peridot.png
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Itens de Solução", "Itens de Solução", "{16654221-9CC4-4B02-A329-AC24440396D5}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Global

--- a/src/Peridot.Veldrid/TextureWrapper.cs
+++ b/src/Peridot.Veldrid/TextureWrapper.cs
@@ -10,13 +10,15 @@ namespace Peridot.Veldrid;
 /// <summary>
 /// A wrapper with <see cref="ITexture2D"/> interface.
 /// </summary>
-public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
+public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper>
+{
     /// <summary>
     /// Creates a new instance of <see cref="TextureWrapper"/>.
     /// </summary>
     /// <param name="texture">The texture.</param>
     /// <exception cref="ArgumentNullException"></exception>
-    public TextureWrapper(Texture texture) {
+    public TextureWrapper(Texture texture)
+    {
         Texture = texture ?? throw new ArgumentNullException(nameof(texture));
     }
 
@@ -28,7 +30,7 @@ public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
     /// <summary>
     /// Size of texture
     /// </summary>
-    public Size Size => new((int) Texture.Width, (int) Texture.Height);
+    public Size Size => new((int)Texture.Width, (int)Texture.Height);
 
     /// <inheritdoc/>
     public bool IsDisposed => Texture.IsDisposed;
@@ -47,7 +49,8 @@ public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
     public override string? ToString() => Texture.ToString();
 
     /// <inheritdoc/>
-    public void Dispose() {
+    public void Dispose()
+    {
         Texture.Dispose();
         GC.SuppressFinalize(this);
     }
@@ -55,7 +58,7 @@ public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
     public static implicit operator TextureWrapper(Texture t) => new(t);
 
     public static implicit operator Texture(TextureWrapper t) => t.Texture;
-
+    
     public static bool operator ==(TextureWrapper left, TextureWrapper right) => left.Equals(right);
 
     public static bool operator !=(TextureWrapper left, TextureWrapper right) => !(left == right);

--- a/src/Peridot.Veldrid/TextureWrapper.cs
+++ b/src/Peridot.Veldrid/TextureWrapper.cs
@@ -5,59 +5,58 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using Veldrid;
 
-namespace Peridot.Veldrid
-{
+namespace Peridot.Veldrid;
+
+/// <summary>
+/// A wrapper with <see cref="ITexture2D"/> interface.
+/// </summary>
+public class TextureWrapper : ITexture2D, IEquatable<TextureWrapper> {
     /// <summary>
-    /// A wrapper with <see cref="ITexture2D"/> interface.
+    /// Creates a new instance of <see cref="TextureWrapper"/>.
     /// </summary>
-    public struct TextureWrapper : ITexture2D, IEquatable<TextureWrapper>
-    {
-        /// <summary>
-        /// Creates a new instance of <see cref="TextureWrapper"/>.
-        /// </summary>
-        /// <param name="texture">The texture.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public TextureWrapper(Texture texture)
-        {
-            if (texture is null)
-                throw new ArgumentNullException(nameof(texture));
-
-            Texture = texture;
-        }
-
-        /// <summary>
-        /// Texture
-        /// </summary>
-        public Texture Texture { get; }
-
-        /// <summary>
-        /// Size of texture
-        /// </summary>
-        public Size Size => new((int)Texture.Width, (int)Texture.Height);
-
-        /// <inheritdoc/>
-        public bool IsDisposed => Texture.IsDisposed;
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => Texture.GetHashCode();
-
-        /// <inheritdoc/>
-        public bool Equals(TextureWrapper other) => Texture == other.Texture;
-
-        /// <inheritdoc/>
-        public override bool Equals([NotNullWhen(true)] object? obj) =>
-            obj is not null && obj is TextureWrapper tw && Equals(tw);
-
-        /// <inheritdoc/>
-        public override string? ToString() => Texture.ToString();
-
-        /// <inheritdoc/>
-        public void Dispose() => Texture.Dispose();
-
-        /// <inheritdoc/>
-        public static implicit operator TextureWrapper(Texture t) => new(t);
-
-        /// <inheritdoc/>
-        public static implicit operator Texture(TextureWrapper t) => t.Texture;
+    /// <param name="texture">The texture.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public TextureWrapper(Texture texture) {
+        Texture = texture ?? throw new ArgumentNullException(nameof(texture));
     }
+
+    /// <summary>
+    /// Texture
+    /// </summary>
+    public Texture Texture { get; }
+
+    /// <summary>
+    /// Size of texture
+    /// </summary>
+    public Size Size => new((int) Texture.Width, (int) Texture.Height);
+
+    /// <inheritdoc/>
+    public bool IsDisposed => Texture.IsDisposed;
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Texture.GetHashCode();
+
+    /// <inheritdoc/>
+    public bool Equals(TextureWrapper? other) => Texture == other?.Texture;
+
+    /// <inheritdoc/>
+    public override bool Equals([NotNullWhen(true)] object? obj) =>
+        obj is TextureWrapper tw && Equals(tw);
+
+    /// <inheritdoc/>
+    public override string? ToString() => Texture.ToString();
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        Texture.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public static implicit operator TextureWrapper(Texture t) => new(t);
+
+    public static implicit operator Texture(TextureWrapper t) => t.Texture;
+
+    public static bool operator ==(TextureWrapper left, TextureWrapper right) => left.Equals(right);
+
+    public static bool operator !=(TextureWrapper left, TextureWrapper right) => !(left == right);
 }


### PR DESCRIPTION
I noticed memory allocations going through the roof, because TextureWrapper was being boxed when sent as an ITexture. It should probably be a class instead. At least my memory allocations have gone away.

(Sorry about the formatting changes 😅 could you maybe add an .editorconfig to keep the style consistent?)